### PR TITLE
fix: unify logger

### DIFF
--- a/comlrl/trainers/actor_critic/ac_base.py
+++ b/comlrl/trainers/actor_critic/ac_base.py
@@ -255,6 +255,30 @@ class ActorCriticTrainerBase:
         if self.wandb_initialized and wandb is not None:
             wandb.log(metrics, step=self.env_step)
 
+    def _domain_metrics_from_rollouts(self, rollouts: List[Any]) -> Dict[str, float]:
+        callback = getattr(self, "metrics_callback", None)
+        if callback is None:
+            return {}
+        extra = callback(rollouts)
+        if not isinstance(extra, dict):
+            return {}
+
+        metrics: Dict[str, float] = {}
+        for key, value in extra.items():
+            try:
+                metrics[str(key)] = float(value)
+            except (TypeError, ValueError):
+                continue
+        return metrics
+
+    def _log_domain_metrics(self, rollouts: List[Any], *, prefix: str = "") -> None:
+        metrics = self._domain_metrics_from_rollouts(rollouts)
+        if not metrics:
+            return
+        if prefix:
+            metrics = {f"{prefix}{key}": value for key, value in metrics.items()}
+        self._log_metrics(metrics)
+
     def _should_log_train(self) -> bool:
         interval = int(getattr(self.args, "logging_steps", 1))
         if interval <= 1:
@@ -337,6 +361,11 @@ class ActorCriticTrainerBase:
     def _run_batch(self, batch, epoch_metrics: Dict[str, List[float]]) -> None:
         for item in batch:
             rollouts = self._collect_rollouts(item)
+            if self.args.num_agents > 0:
+                # Count joint-action reward evaluations (one per agent group).
+                self.env_step += len(rollouts) // self.args.num_agents
+            self._log_domain_metrics(rollouts)
+
             ready_agents: List[int] = []
             for sample in rollouts:
                 agent_idx = sample.agent_idx
@@ -346,9 +375,6 @@ class ActorCriticTrainerBase:
                     ready_agents.append(agent_idx)
             if ready_agents:
                 self._drain_ready_agent_buffers(ready_agents, epoch_metrics)
-            if self.args.num_agents > 0:
-                # Count joint-action reward evaluations (one per agent group).
-                self.env_step += len(rollouts) // self.args.num_agents
 
     def _flush_buffers(self, epoch_metrics: Dict[str, List[float]]) -> None:
         ready_agents = [
@@ -386,6 +412,7 @@ class ActorCriticTrainerBase:
 
         num_samples = int(self.args.eval_num_samples)
         turn_groups: Dict[int, List[Any]] = {}
+        domain_metric_values: Dict[str, List[float]] = defaultdict(list)
         seen = 0
 
         self._in_eval = True
@@ -397,6 +424,9 @@ class ActorCriticTrainerBase:
                         for sample in rollouts:
                             t_idx = int(sample.metadata.get("turn_idx", 0))
                             turn_groups.setdefault(t_idx, []).append(sample)
+                        domain_metrics = self._domain_metrics_from_rollouts(rollouts)
+                        for key, value in domain_metrics.items():
+                            domain_metric_values[key].append(value)
                         seen += 1
                         if seen >= num_samples:
                             break
@@ -410,6 +440,10 @@ class ActorCriticTrainerBase:
             metrics = self._summarize_rollout_metrics(samples)
             for key, value in metrics.items():
                 eval_log[f"eval/turn_{turn_idx + 1}/{key}"] = value
+
+        for key, values in domain_metric_values.items():
+            if values:
+                eval_log[f"eval/{key}"] = float(sum(values) / len(values))
 
         if eval_log:
             self._log_metrics(eval_log)

--- a/comlrl/trainers/actor_critic/ac_base.py
+++ b/comlrl/trainers/actor_critic/ac_base.py
@@ -167,23 +167,6 @@ class ActorCriticTrainerBase:
         if returns.numel() > 0 and torch.isfinite(returns).all():
             metrics["expected_return"] = float(returns.mean().item())
 
-        values = torch.stack(
-            [sample.old_value.view(-1)[0] for sample in rollouts]
-        ).float()
-        if values.numel() > 0 and torch.isfinite(values).all():
-            metrics["value_pred_mean"] = float(values.mean().item())
-
-        targets = [sample.metadata.get("value_target") for sample in rollouts]
-        if any(t is not None for t in targets):
-            target_vals = torch.stack(
-                [
-                    (t if t is not None else sample.returns).view(-1)[0]
-                    for sample, t in zip(rollouts, targets)
-                ]
-            ).float()
-            if target_vals.numel() > 0 and torch.isfinite(target_vals).all():
-                metrics["value_target_mean"] = float(target_vals.mean().item())
-
         reference_kls = [
             float(sample.metadata.get("reference_kl", 0.0))
             for sample in rollouts

--- a/comlrl/trainers/actor_critic/iac.py
+++ b/comlrl/trainers/actor_critic/iac.py
@@ -1048,7 +1048,7 @@ class IACTrainer(ActorCriticTrainerBase):
         return logprob_sum
 
     # Actor-Critic update logic
-    def _ac_step(self, agent_idx: int, batch: List[RolloutSample]) -> Dict[str, float]:
+    def _ac_step(self, agent_idx: int, batch: List[RolloutSample]) -> None:
         agent_model = self.agents[agent_idx]
         critic_model = (
             self.critics[agent_idx] if self.args.use_separate_critic else None
@@ -1173,11 +1173,6 @@ class IACTrainer(ActorCriticTrainerBase):
             (actor_total + value_total).backward()
             agent_optimizer.step()
 
-        return {
-            "policy_loss": actor_loss.detach().item(),
-            "value_loss": value_loss.detach().item(),
-        }
-
     def _update(
         self, agent_idx: int, rollouts: List[RolloutSample]
     ) -> Dict[str, float]:
@@ -1214,9 +1209,7 @@ class IACTrainer(ActorCriticTrainerBase):
         random.shuffle(rollouts)
         for start in range(0, len(rollouts), self.args.train_batch_size):
             batch = rollouts[start : start + self.args.train_batch_size]
-            step_metrics = self._ac_step(agent_idx, batch)
-            for key, value in step_metrics.items():
-                metrics[key].append(value)
+            self._ac_step(agent_idx, batch)
 
         averaged = {
             key: float(sum(values) / len(values))

--- a/comlrl/trainers/actor_critic/iac.py
+++ b/comlrl/trainers/actor_critic/iac.py
@@ -60,7 +60,7 @@ class IACConfig:
     agent_devices: Optional[Union[str, Sequence[str]]] = None
     critic_devices: Optional[Union[str, Sequence[str]]] = None
     external_prompt_passthrough: bool = False
-    discount: float = 0.9
+    discount: float = 1.0
     num_generations: int = 1
     eval_interval: int = 16
     eval_num_samples: int = 4
@@ -775,7 +775,7 @@ class IACTrainer(ActorCriticTrainerBase):
             [] for _ in range(self.args.num_agents)
         ]
         rollouts: List[RolloutSample] = []
-        gamma = float(getattr(self.args, "discount", 0.9))
+        value_discount = float(getattr(self.args, "discount", 1.0))
 
         for turn_idx in range(num_turns):
             if turn_idx == 0:
@@ -889,7 +889,7 @@ class IACTrainer(ActorCriticTrainerBase):
                 r = float(sample.returns.view(-1)[0].item())
                 if t < len(traj) - 1:
                     next_v = float(traj[t + 1].old_value.view(-1)[0].item())
-                    target = r + gamma * next_v
+                    target = r + value_discount * next_v
                 else:
                     target = r
                 sample.metadata["adv_target"] = torch.tensor([target]).cpu()
@@ -899,7 +899,8 @@ class IACTrainer(ActorCriticTrainerBase):
             future = 0.0
             for sample in reversed(per_agent_samples[agent_idx]):
                 immediate = float(sample.returns.view(-1)[0].item())
-                future = immediate + gamma * future
+                # Logged return is the undiscounted reward sum from this turn onward.
+                future = immediate + future
                 sample.returns = torch.tensor([future], dtype=torch.float32)
                 sample.advantage = torch.zeros_like(sample.returns)
                 sample.normalized_advantage = None

--- a/comlrl/trainers/actor_critic/iac.py
+++ b/comlrl/trainers/actor_critic/iac.py
@@ -749,6 +749,9 @@ class IACTrainer(ActorCriticTrainerBase):
                         advantage=advantage_cpu,
                         metadata={
                             "char_length": data["char_lengths"][i],
+                            "turn_idx": 0,
+                            "generation_idx": i,
+                            "batch_item": item,
                             **kl_meta,
                             "value_target": returns_cpu,
                         },
@@ -864,6 +867,8 @@ class IACTrainer(ActorCriticTrainerBase):
                     metadata={
                         "char_length": data["char_lengths"][0],
                         "turn_idx": turn_idx,
+                        "generation_idx": 0,
+                        "batch_item": item,
                         **kl_meta,
                     },
                 )
@@ -1205,11 +1210,6 @@ class IACTrainer(ActorCriticTrainerBase):
             if torch.isfinite(vals).all():
                 metrics["reference_kl_penalty_mean"].append(vals.mean().item())
 
-        if self.metrics_callback is not None:
-            extra = self.metrics_callback(rollouts)
-            if isinstance(extra, dict):
-                for key, value in extra.items():
-                    metrics[key].append(float(value))
         random.shuffle(rollouts)
         for start in range(0, len(rollouts), self.args.train_batch_size):
             batch = rollouts[start : start + self.args.train_batch_size]

--- a/comlrl/trainers/actor_critic/maac.py
+++ b/comlrl/trainers/actor_critic/maac.py
@@ -1,7 +1,6 @@
 import inspect
 import os
 import random
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -1002,7 +1001,7 @@ class MAACTrainer(ActorCriticTrainerBase):
 
         return response_log_probs.sum(dim=-1)
 
-    def _ac_step(self, agent_idx: int, batch: List[RolloutSample]) -> Dict[str, float]:
+    def _ac_step(self, agent_idx: int, batch: List[RolloutSample]) -> None:
         agent_model = self.agents[agent_idx]
         agent_optimizer = self.agent_optimizers[agent_idx]
 
@@ -1070,11 +1069,6 @@ class MAACTrainer(ActorCriticTrainerBase):
         value_total.backward()
         self.critic_optimizer.step()
 
-        return {
-            "policy_loss": actor_loss.detach().item(),
-            "value_loss": value_loss.detach().item(),
-        }
-
     def _update(
         self, agent_idx: int, rollouts: List[RolloutSample]
     ) -> Dict[str, float]:
@@ -1085,18 +1079,9 @@ class MAACTrainer(ActorCriticTrainerBase):
         self._prepare_advantages(rollouts)
         random.shuffle(rollouts)
 
-        loss_metrics = defaultdict(list)
         for start in range(0, len(rollouts), self.args.train_batch_size):
             batch = rollouts[start : start + self.args.train_batch_size]
-            step_metrics = self._ac_step(agent_idx, batch)
-            for key, value in step_metrics.items():
-                loss_metrics[key].append(value)
-        averaged_losses = {
-            key: float(sum(values) / len(values))
-            for key, values in loss_metrics.items()
-            if values
-        }
-        metrics.update(averaged_losses)
+            self._ac_step(agent_idx, batch)
         return metrics
 
     def _on_epoch_end(
@@ -1105,30 +1090,9 @@ class MAACTrainer(ActorCriticTrainerBase):
         total_epochs: int,
         epoch_metrics: Dict[str, List[float]],
     ) -> None:
-        num_turns = max(1, int(getattr(self.args, "num_turns", 1)))
-        epoch_log: Dict[str, float] = {}
-        for turn_idx in range(num_turns):
-            prefix = f"turn_{turn_idx + 1}/"
-
-            def _maybe_log(metric_key: str, epoch_key: str) -> None:
-                values = epoch_metrics.get(prefix + metric_key)
-                if values:
-                    epoch_log[prefix + epoch_key] = float(sum(values) / len(values))
-
-            _maybe_log("reward_mean", "epoch_reward_mean")
-            _maybe_log("expected_return", "epoch_avg_return")
-            _maybe_log("value_pred_mean", "epoch_value_pred_mean")
-            _maybe_log("value_target_mean", "epoch_value_target_mean")
-            _maybe_log("policy_loss", "epoch_policy_loss")
-            _maybe_log("value_loss", "epoch_value_loss")
-
-        if epoch_log:
-            self._log_metrics(epoch_log)
-
         summary = self._summarize_epoch_metrics(epoch_metrics)
         if summary and getattr(self, "verbose", True) and self.dist_env.is_main:
-            to_print = epoch_log if epoch_log else summary
-            print(f"Epoch {epoch + 1}/{total_epochs} metrics: {to_print}")
+            print(f"Epoch {epoch + 1}/{total_epochs} metrics: {summary}")
 
     def save_model(self, output_dir: str) -> None:
         if not self.dist_env.is_main:

--- a/comlrl/trainers/actor_critic/maac.py
+++ b/comlrl/trainers/actor_critic/maac.py
@@ -56,7 +56,7 @@ class MAACConfig:
     agent_devices: Optional[Union[str, Sequence[str]]] = None
     critic_devices: Optional[Union[str, Sequence[str]]] = None
     external_prompt_passthrough: bool = False
-    discount: float = 0.9
+    discount: float = 1.0
     critic_type: str = "v"  # "v" (V(s)) or "q" (Q(s,a))
     early_termination_threshold: Optional[float] = -0.2
     eval_interval: int = 16
@@ -754,7 +754,7 @@ class MAACTrainer(ActorCriticTrainerBase):
             [] for _ in range(self.args.num_agents)
         ]
         rollouts: List[RolloutSample] = []
-        gamma = float(getattr(self.args, "discount", 0.9))
+        value_discount = float(getattr(self.args, "discount", 1.0))
 
         for turn_idx in range(num_turns):
             if turn_idx == 0:
@@ -900,7 +900,7 @@ class MAACTrainer(ActorCriticTrainerBase):
                 r = float(sample.returns.view(-1)[0].item())
                 if t < len(traj) - 1:
                     next_v = float(traj[t + 1].old_value.view(-1)[0].item())
-                    target = r + gamma * next_v
+                    target = r + value_discount * next_v
                 else:
                     target = r
                 sample.metadata["adv_target"] = torch.tensor([target]).cpu()
@@ -910,7 +910,8 @@ class MAACTrainer(ActorCriticTrainerBase):
             future = 0.0
             for sample in reversed(per_agent_samples[agent_idx]):
                 immediate = float(sample.returns.view(-1)[0].item())
-                future = immediate + gamma * future
+                # Logged return is the undiscounted reward sum from this turn onward.
+                future = immediate + future
                 sample.returns = torch.tensor([future], dtype=torch.float32)
                 sample.advantage = torch.zeros_like(sample.returns)
                 sample.normalized_advantage = None

--- a/comlrl/trainers/actor_critic/maac.py
+++ b/comlrl/trainers/actor_critic/maac.py
@@ -727,6 +727,8 @@ class MAACTrainer(ActorCriticTrainerBase):
                             "joint_attention_mask": joint_mask.detach().cpu(),
                             "joint_prompt_len": joint_len,
                             "turn_idx": 0,
+                            "generation_idx": i,
+                            "batch_item": item,
                             "adv_target": shaped_reward_cpu,
                             **kl_meta,
                         },
@@ -737,10 +739,6 @@ class MAACTrainer(ActorCriticTrainerBase):
             r = float(sample.returns.view(-1)[0].item())
             sample.metadata["value_target"] = torch.tensor([r]).cpu()
 
-        if self.metrics_callback is not None:
-            extra = self.metrics_callback(rollouts)
-            if isinstance(extra, dict):
-                self._log_metrics(extra)
         return rollouts
 
     def _collect_rollouts_multi_turn(
@@ -880,6 +878,8 @@ class MAACTrainer(ActorCriticTrainerBase):
                         "joint_attention_mask": joint_mask.detach().cpu(),
                         "joint_prompt_len": joint_len,
                         "turn_idx": turn_idx,
+                        "generation_idx": 0,
+                        "batch_item": item,
                         **kl_meta,
                     },
                 )
@@ -915,10 +915,6 @@ class MAACTrainer(ActorCriticTrainerBase):
                 sample.advantage = torch.zeros_like(sample.returns)
                 sample.normalized_advantage = None
 
-        if self.metrics_callback is not None:
-            extra = self.metrics_callback(rollouts)
-            if isinstance(extra, dict):
-                self._log_metrics(extra)
         return rollouts
 
     def _expand_rewards(self, rewards: List[float], num_ret: int) -> List[List[float]]:

--- a/comlrl/trainers/reinforce/magrpo.py
+++ b/comlrl/trainers/reinforce/magrpo.py
@@ -793,13 +793,6 @@ class MAGRPOTrainer:
 
         # Create the data pipeline for generating examples
         for epoch in range(0, int(self.args.num_train_epochs)):
-            # No per-agent reward tracking in single reward mode
-
-            # Turn tracking for all cases (including single-turn)
-            epoch_turn_rewards = [
-                [] for _ in range(self.args.num_turns)
-            ]  # immediate rewards
-            epoch_turn_returns = [[] for _ in range(self.args.num_turns)]  # returns
             dl = self.get_train_dataloader()
             if getattr(self, "verbose", True):
                 it = enumerate(
@@ -823,8 +816,6 @@ class MAGRPOTrainer:
                 # Unified training step (returns-based, backward updates)
                 batch_loss, _batch_stats = self._train_step_returns(
                     batch_item,
-                    epoch_turn_rewards,
-                    epoch_turn_returns,
                     **kwargs,
                 )
 
@@ -835,27 +826,9 @@ class MAGRPOTrainer:
             ]
             self._drain_ready_buffers(ready_agents)
 
-            # Log per-turn epoch averages inline (avoid custom system/* metrics)
-            epoch_log: Dict[str, Any] = {}
-            n_turns = max(1, int(self.args.num_turns))
-            for turn_idx in range(n_turns):
-                if epoch_turn_rewards and epoch_turn_rewards[turn_idx]:
-                    epoch_log[f"turn_{turn_idx + 1}/epoch_reward_mean"] = float(
-                        np.mean(epoch_turn_rewards[turn_idx])
-                    )
-                if epoch_turn_returns and epoch_turn_returns[turn_idx]:
-                    epoch_log[f"turn_{turn_idx + 1}/epoch_avg_return"] = float(
-                        np.mean(epoch_turn_returns[turn_idx])
-                    )
-
-            if epoch_log and self.wandb_initialized and wandb.run is not None:
-                wandb.log(epoch_log, step=self.env_step)
-
     def _train_step_returns(
         self,
         batch_item,
-        epoch_turn_rewards,
-        epoch_turn_returns,
         **kwargs,
     ):
         """Branching rollout with returns; updates backward from last turn to first.
@@ -970,11 +943,6 @@ class MAGRPOTrainer:
             else:
                 raise ValueError(f"Unsupported joint_mode: {joint_mode}")
 
-            if 0 <= turn_idx < len(epoch_turn_rewards):
-                epoch_turn_rewards[turn_idx].append(
-                    np.mean(rewards_vec) if rewards_vec else 0.0
-                )
-
             # Per-node means for batch-level summaries
             self.env_step += len(rewards_vec)
             node_env_step = int(self.env_step)
@@ -1067,11 +1035,10 @@ class MAGRPOTrainer:
         # After returns computed, record per-turn mean returns
         def record_turn_returns(node):
             t = node["turn"]
-            if 0 <= t < len(epoch_turn_returns):
+            if 0 <= t < len(turn_return_node_means):
                 vals = node.get("returns") or []
                 if vals:
                     mean_ret = float(np.mean(vals))
-                    epoch_turn_returns[t].append(mean_ret)
                     turn_return_node_means[t].append(mean_ret)
             for ch in node["children"]:
                 record_turn_returns(ch)

--- a/comlrl/trainers/reinforce/magrpo.py
+++ b/comlrl/trainers/reinforce/magrpo.py
@@ -58,7 +58,7 @@ class MAGRPOConfig:
 
     # Multi-turn / tree rollout
     num_turns: int = 2
-    discount: float = 0.9
+    discount: float = 1.0
     joint_mode: str = "aligned"
     early_termination_threshold: Optional[float] = -0.2
     external_prompt_passthrough: bool = False
@@ -599,7 +599,6 @@ class MAGRPOTrainer:
         n_turns = self.args.num_turns
         if n_turns > 0 and eval_turn_rewards and eval_turn_rewards[0]:
             n_samp = len(eval_turn_rewards[0])
-            gamma = float(getattr(self.args, "discount", 0.9))
             sum_returns = [0.0] * n_turns
             for s in range(n_samp):
                 rs = [
@@ -609,7 +608,8 @@ class MAGRPOTrainer:
                 ret = [0.0] * n_turns
                 ret[-1] = rs[-1]
                 for t in range(n_turns - 2, -1, -1):
-                    ret[t] = rs[t] + gamma * ret[t + 1]
+                    # Evaluation return is the undiscounted reward sum from this turn onward.
+                    ret[t] = rs[t] + ret[t + 1]
                 for t in range(n_turns):
                     sum_returns[t] += ret[t]
             for t in range(n_turns):
@@ -868,8 +868,6 @@ class MAGRPOTrainer:
         """
         num_turns = int(self.args.num_turns)
         num_gens = int(self.args.num_generations)
-        gamma = float(getattr(self.args, "discount", 0.9))
-
         # Per-turn accumulators for batch-level summaries
         turn_reward_node_means: List[List[float]] = [[] for _ in range(num_turns)]
         turn_return_node_means: List[List[float]] = [[] for _ in range(num_turns)]
@@ -1059,7 +1057,8 @@ class MAGRPOTrainer:
                 child_node = node["children"][j]
                 child_returns = compute_returns(child_node)
                 mean_child = float(np.mean(child_returns)) if child_returns else 0.0
-                parent_returns.append(rj + gamma * mean_child)
+                # Training return is the undiscounted reward sum over the rollout tree.
+                parent_returns.append(rj + mean_child)
             node["returns"] = parent_returns
             return parent_returns
 

--- a/comlrl/trainers/reinforce/magrpo.py
+++ b/comlrl/trainers/reinforce/magrpo.py
@@ -613,10 +613,10 @@ class MAGRPOTrainer:
                 for t in range(n_turns):
                     sum_returns[t] += ret[t]
             for t in range(n_turns):
-                extra_eval_metrics[f"eval/turn_{t+1}/mean_reward"] = float(
+                extra_eval_metrics[f"eval/turn_{t+1}/reward_mean"] = float(
                     np.mean(eval_turn_rewards[t]) if eval_turn_rewards[t] else 0.0
                 )
-                extra_eval_metrics[f"eval/turn_{t+1}/mean_return"] = float(
+                extra_eval_metrics[f"eval/turn_{t+1}/expected_return"] = float(
                     sum_returns[t] / n_samp if n_samp > 0 else 0.0
                 )
 


### PR DESCRIPTION
I have put up with slight inconsistencies in the metric logging parameter names across different algorithms for a long time. Today, I finally decided I’d had enough, so I opened a PR.